### PR TITLE
Fix nonblockingmain test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.2.0]: https://github.com/mec07/rununtil/compare/v0.1.0...v0.2.0
 ### Changed
 - Deprecate: functions KillSignal, Signals, and Killed
-- Replace them with: AwaitKillSignal, AwaitKillSignals and SimulateKillSignal
+- Replace them with: AwaitKillSignal, AwaitKillSignals and CancelAll
 
 ### Fixed
 - There was a problem with sending a kill signal to a nonblocking main function.
-  This has been fixed by providing the SimulateKillSignal method.
+  This has been fixed by providing the CancelAll method.
 
 ## [0.1.0] - 2019-06-12
 [0.1.0]: https://github.com/mec07/rununtil/compare/v0.0.1...v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-[Unreleased]: https://github.com/mec07/rununtil/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/mec07/rununtil/compare/v0.2.0...HEAD
+
+## [0.2.0] - 2019-06-12
+[0.2.0]: https://github.com/mec07/rununtil/compare/v0.1.0...v0.2.0
+### Changed
+- Deprecate: functions KillSignal, Signals, and Killed
+- Replace them with: AwaitKillSignal, AwaitKillSignals and SimulateKillSignal
+
+### Fixed
+- There was a problem with sending a kill signal to a nonblocking main function.
+  This has been fixed by providing the SimulateKillSignal method.
 
 ## [0.1.0] - 2019-06-12
 [0.1.0]: https://github.com/mec07/rununtil/compare/v0.0.1...v0.1.0

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+.PHONY: lint
+lint:
+	golangci-lint run ./...
+
+.PHONY: test
+test:
+	go test -v -coverprofile=cover.out -covermode=atomic -coverpkg=./... ./...
+
+.PHONY: cover
+cover:
+	go tool cover -html=cover.out

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # rununtil
-Go library to run a function until a kill signal is recieved
+Go library to run a function until a kill signal is recieved.
+
+See the docs: https://godoc.org/github.com/mec07/rununtil

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/mec07/rununtil
 
 go 1.12
 
-require github.com/pkg/errors v0.8.1
+require (
+	github.com/google/uuid v1.1.1
+	github.com/pkg/errors v0.8.1
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
+github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/rununtil.go
+++ b/rununtil.go
@@ -171,21 +171,14 @@ func SimulateKillSignal() {
 // SIGINT or SIGTERM, at which point it executes the graceful shutdown function.
 // Deprecated. Please use AwaitKillSignal.
 func KillSignal(runner RunnerFunc) {
-	Signals(runner, syscall.SIGINT, syscall.SIGTERM)
+	AwaitKillSignal(runner)
 }
 
 // Signals runs the provided runner function until the specified signals have
 // been recieved.
 // Deprecated. Please use AwaitKillSignals.
 func Signals(runner RunnerFunc, signals ...os.Signal) {
-	c := make(chan os.Signal, 1)
-	signal.Notify(c, signals...)
-
-	shutdown := runner()
-	defer shutdown()
-
-	// Wait for a kill signal
-	<-c
+	AwaitKillSignals(signals, runner)
 }
 
 // Killed is used for testing a function that is using rununtil.KillSignal.

--- a/rununtil.go
+++ b/rununtil.go
@@ -2,7 +2,7 @@
 
 Usage
 
-The main usage of rununtil is to run a webserver or other function until a SIGINT or SIGTERM signal has been received.
+The main usage of rununtil is to run your main app indefinitely until a SIGINT or SIGTERM signal has been received.
 The runner function can do some setup but it should not run indefinitely, instead it should start go routines which can run in the background.
 The runner function should return a graceful shutdown function that will be called once the signal has been received.
 For example:
@@ -29,6 +29,7 @@ For example:
 		rununtil.AwaitKillSignal(Runner)
 	}
 
+The `AwaitKillSignal` function blocks until either a kill signal has been received or `SimulateKillSignal` has been triggered.
 A nice pattern is to create a function that takes in the various depencies required, for example, a logger (but could be anything, e.g. configs, database, etc.), and returns a runner function:
 	func NewRunner(log *zerolog.Logger) rununtil.RunnerFunc {
 		return rununtil.RunnerFunc(func() rununtil.ShutdownFunc {
@@ -59,31 +60,64 @@ A nice pattern is to create a function that takes in the various depencies requi
 		rununtil.AwaitKillSignal(NewRunner(logger))
 	}
 
-It is of course possible to specify which signals you would like to use to kill your application using the `Signals` function, for example:
-	rununtil.Signals(NewRunner(logger), syscall.SIGKILL, syscall.SIGHUP, syscall.SIGINT)
+It is of course possible to specify which signals you would like to use to kill your application using the `AwaitKillSignals` function, for example:
+	rununtil.AwaitKillSignals([]os.Signal{syscall.SIGKILL, syscall.SIGHUP, syscall.SIGINT}, NewRunner(logger))
 
-For testing purposes you may want to run your main function, which is using `rununtil.AwaitKillSignal`, and send it a kill signal when you're done with your tests. To aid with this you can use:
-	kill := rununtil.Killed(main)
+For testing purposes you may want to run your main function, which is using `rununtil.AwaitKillSignal`, and then kill it by simulating sending a kill signal when you're done with your tests. To aid with this you can:
+	go main()
+	... do your tests ...
+	rununtil.SimulateKillSignal()
 
-where `kill` is a function that sends a kill signal to the main function when executed (its type is context.CancelFunc).
+The `SimulateKillSignal` function kills all of the `RunnerFuncs` that you may have started in your main function.
+
+The old functions `KillSignal`, `Signals` and `Killed` are still here (for backwards compatibility), but they have been deprecated.
+Please use `AwaitKillSignal` instead of `KillSignal`, `AwaitKillSignals` instead of `Signals` and `SimulateKillSignal` instead of `Killed` followed by executing the `context.CancelFunc` that it returns.
 */
 package rununtil
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
+
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
 )
 
 type canceller struct {
-	signal chan struct{}
+	signals map[string]chan struct{}
+	mux     sync.Mutex
+}
+
+func (canc *canceller) addChannel(key string, c chan struct{}) {
+	canc.mux.Lock()
+	canc.signals[key] = c
+	canc.mux.Unlock()
+}
+
+func (canc *canceller) removeChannel(key string) {
+	canc.mux.Lock()
+	delete(canc.signals, key)
+	canc.mux.Unlock()
+}
+
+func (canc *canceller) cancelAll() {
+	canc.mux.Lock()
+	for key := range canc.signals {
+		close(canc.signals[key])
+	}
+	canc.mux.Unlock()
 }
 
 var globalCanceller canceller
 
 func init() {
-	globalCanceller.signal = make(chan struct{})
+	globalCanceller.mux.Lock()
+	globalCanceller.signals = make(map[string]chan struct{})
+	globalCanceller.mux.Unlock()
 }
 
 // ShutdownFunc is a function that should be returned by a RunnerFunc which
@@ -108,6 +142,10 @@ func AwaitKillSignals(signals []os.Signal, runnerFuncs ...RunnerFunc) {
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, signals...)
 
+	finish := make(chan struct{})
+	uuid := uuid.New()
+	globalCanceller.addChannel(uuid.String(), finish)
+
 	for _, runner := range runnerFuncs {
 		shutdown := runner()
 		defer shutdown()
@@ -117,21 +155,50 @@ func AwaitKillSignals(signals []os.Signal, runnerFuncs ...RunnerFunc) {
 	select {
 	case <-c:
 		break
-	case <-globalCanceller.signal:
+	case <-finish:
 		break
 	}
+	globalCanceller.removeChannel(uuid.String())
 }
 
-// RunMain is used for testing a function that is using
-// rununtil.AwaitKillSignal(s).  It runs the function provided and returns a
-// context.CancelFunc, which can be called to kill the function. A sample usage
-// of this could be:
-//	kill := rununtil.RunMain(main)
+// SimulateKillSignal will stop all the awaits in the same way that a kill
+// signal would stop them.
+func SimulateKillSignal() {
+	globalCanceller.cancelAll()
+}
+
+// KillSignal runs the provided runner function until it receives a kill signal,
+// SIGINT or SIGTERM, at which point it executes the graceful shutdown function.
+// Deprecated. Please use AwaitKillSignal.
+func KillSignal(runner RunnerFunc) {
+	Signals(runner, syscall.SIGINT, syscall.SIGTERM)
+}
+
+// Signals runs the provided runner function until the specified signals have
+// been recieved.
+// Deprecated. Please use AwaitKillSignals.
+func Signals(runner RunnerFunc, signals ...os.Signal) {
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, signals...)
+
+	shutdown := runner()
+	defer shutdown()
+
+	// Wait for a kill signal
+	<-c
+}
+
+// Killed is used for testing a function that is using rununtil.KillSignal.
+// It runs the function provided and sends a SIGINT signal to kill it when
+// the returned context.CancelFunc is executed. A sample usage of this could be:
+//	kill := rununtil.Killed(main)
 //	... do some stuff, e.g. send some requests to the webserver ...
 //	kill()
 //
-// where main is a function that is using rununtil.AwaitKillSignal(s).
-func RunMain(main func()) context.CancelFunc {
+// where main is a function that is using rununtil.KillSignal.
+// Deprecated. Please just run your main function and use
+// rununtil.SimulateKillSignal.
+func Killed(main func()) context.CancelFunc {
 	ctx, cancel := context.WithCancel(context.Background())
 	go runMain(ctx, main)
 
@@ -139,14 +206,18 @@ func RunMain(main func()) context.CancelFunc {
 }
 
 func runMain(ctx context.Context, main func()) {
-	go killMainWhenDone(ctx)
+	p, err := os.FindProcess(os.Getpid())
+	if err != nil {
+		fmt.Printf("ERROR: %+v\n", errors.Wrap(err, "trying to get PID"))
+	}
+	go killMainWhenDone(ctx, p)
 	main()
 }
 
-func killMainWhenDone(ctx context.Context) {
+func killMainWhenDone(ctx context.Context, p *os.Process) {
 	<-ctx.Done()
-	close(globalCanceller.signal)
-	globalCanceller.signal = make(chan struct{})
-}
 
-// SimulateKillSignal...
+	if err := p.Signal(syscall.SIGINT); err != nil {
+		fmt.Printf("ERROR: %+v\n", errors.Wrap(err, "trying to kill main"))
+	}
+}

--- a/rununtil.go
+++ b/rununtil.go
@@ -71,7 +71,7 @@ For testing purposes you may want to run your main function, which is using `run
 The `SimulateKillSignal` function kills all of the `RunnerFuncs` that you may have started in your main function.
 
 The old functions `KillSignal`, `Signals` and `Killed` are still here (for backwards compatibility), but they have been deprecated.
-Please use `AwaitKillSignal` instead of `KillSignal`, `AwaitKillSignals` instead of `Signals` and `SimulateKillSignal` instead of `Killed` followed by executing the `context.CancelFunc` that it returns.
+Please use `AwaitKillSignal` instead of `KillSignal`, `AwaitKillSignals` instead of `Signals`, and `SimulateKillSignal` instead of `Killed` (now you can just rain main and then issue the simulated kill signal).
 */
 package rununtil
 

--- a/rununtil.go
+++ b/rununtil.go
@@ -217,7 +217,5 @@ func runMain(ctx context.Context, main func()) {
 func killMainWhenDone(ctx context.Context, p *os.Process) {
 	<-ctx.Done()
 
-	if err := p.Signal(syscall.SIGINT); err != nil {
-		fmt.Printf("ERROR: %+v\n", errors.Wrap(err, "trying to kill main"))
-	}
+	SimulateKillSignal()
 }

--- a/rununtil_test.go
+++ b/rununtil_test.go
@@ -27,11 +27,11 @@ func helperMakeFakeRunner(hasBeenShutdown *bool) rununtil.RunnerFunc {
 
 func helperMakeMain(hasBeenKilled *bool) func() {
 	return func() {
-		rununtil.KillSignal(helperMakeFakeRunner(hasBeenKilled))
+		rununtil.AwaitKillSignal(helperMakeFakeRunner(hasBeenKilled))
 	}
 }
 
-func TestRunUntilKillSignal(t *testing.T) {
+func TestRununtilAwaitKillSignal(t *testing.T) {
 	table := []struct {
 		name   string
 		signal os.Signal
@@ -55,7 +55,7 @@ func TestRunUntilKillSignal(t *testing.T) {
 			}
 
 			go helperSendSignal(t, p, &sentSignal, test.signal, 1*time.Millisecond)
-			rununtil.KillSignal(helperMakeFakeRunner(&hasBeenShutdown))
+			rununtil.AwaitKillSignal(helperMakeFakeRunner(&hasBeenShutdown))
 			if !sentSignal {
 				t.Fatal("expected signal to have been sent")
 			}
@@ -66,14 +66,66 @@ func TestRunUntilKillSignal(t *testing.T) {
 	}
 }
 
-func TestRunUntilKilled(t *testing.T) {
+func TestRununtilAwaitKillSignal_MultipleRunnerFuncs(t *testing.T) {
+	var hasBeenShutdown1, hasBeenShutdown2, hasBeenShutdown3 bool
+	var sentSignal bool
+
+	p, err := os.FindProcess(os.Getpid())
+	if err != nil {
+		t.Fatalf("Unexpected error when finding process: %v", err)
+	}
+
+	go helperSendSignal(t, p, &sentSignal, syscall.SIGINT, time.Millisecond)
+
+	rununtil.AwaitKillSignal(
+		helperMakeFakeRunner(&hasBeenShutdown1),
+		helperMakeFakeRunner(&hasBeenShutdown2),
+		helperMakeFakeRunner(&hasBeenShutdown3),
+	)
+
+	if !sentSignal {
+		t.Fatal("expected signal to have been sent")
+	}
+	if !hasBeenShutdown1 {
+		t.Fatal("expected the shutdown function 1 to have been called")
+	}
+	if !hasBeenShutdown2 {
+		t.Fatal("expected the shutdown function 2 to have been called")
+	}
+	if !hasBeenShutdown3 {
+		t.Fatal("expected the shutdown function 3 to have been called")
+	}
+}
+
+func TestRununtilRunMain(t *testing.T) {
 	var hasBeenKilled bool
-	kill := rununtil.Killed(helperMakeMain(&hasBeenKilled))
-	kill()
+	cancel := rununtil.RunMain(helperMakeMain(&hasBeenKilled))
+	cancel()
 
 	// yield control back to scheduler so that killing can actually happen
 	time.Sleep(time.Millisecond)
 	if !hasBeenKilled {
 		t.Fatal("expected main to have been killed")
 	}
+}
+
+// If we send a kill signal to a function that doesn't actually block then we
+// end up with a failed test.
+// Need to run just this test to see the effect:
+// go test -v -run TestRunUntilKilled_NonblockingMain
+// This test was made to pass by adding the globalCanceller.signal
+func TestRununtilRunMain_NonblockingMain(t *testing.T) {
+	kill := rununtil.RunMain(func() {})
+	kill()
+}
+
+func TestRununtilRunMain_NonblockingMainMultipleTimes(t *testing.T) {
+	kill := rununtil.RunMain(func() {})
+	kill()
+
+	kill = rununtil.RunMain(func() {})
+	kill()
+
+	kill = rununtil.RunMain(func() {})
+	kill()
 }

--- a/rununtil_test.go
+++ b/rununtil_test.go
@@ -151,3 +151,12 @@ func TestRununtilSimulateKillSignal_Threadsafe(t *testing.T) {
 		rununtil.SimulateKillSignal()
 	}
 }
+
+// Annoyingly this test has to be run by itself to actually fail...
+//	go test -v -run TestKilled_FailsForNonblockingMain
+// Fixed test by not actually sending a kill signal anymore --
+// it now calls rununtil.SimulateKillSignal().
+func TestKilled_FailsForNonblockingMain(t *testing.T) {
+	cancel := rununtil.Killed(func() {})
+	cancel()
+}

--- a/rununtil_test.go
+++ b/rununtil_test.go
@@ -109,7 +109,7 @@ func TestRununtilKilled(t *testing.T) {
 	}
 }
 
-func TestRununtilSimulateKillSignal(t *testing.T) {
+func TestRununtilCancelAll(t *testing.T) {
 	var hasBeenKilled bool
 	rununtil.Killed(helperMakeMain(&hasBeenKilled))
 
@@ -117,7 +117,7 @@ func TestRununtilSimulateKillSignal(t *testing.T) {
 	// start
 	time.Sleep(time.Millisecond)
 
-	rununtil.SimulateKillSignal()
+	rununtil.CancelAll()
 
 	// yield control back to scheduler so that killing can actually happen
 	time.Sleep(time.Millisecond)
@@ -126,7 +126,7 @@ func TestRununtilSimulateKillSignal(t *testing.T) {
 	}
 }
 
-func TestRununtilSimulateKillSignal_MultipleTimes(t *testing.T) {
+func TestRununtilCancelAll_MultipleTimes(t *testing.T) {
 	var hasBeenKilled bool
 	for idx := 0; idx < 100; idx++ {
 		hasBeenKilled = false
@@ -136,7 +136,7 @@ func TestRununtilSimulateKillSignal_MultipleTimes(t *testing.T) {
 		// start
 		time.Sleep(time.Millisecond)
 
-		rununtil.SimulateKillSignal()
+		rununtil.CancelAll()
 
 		// yield control back to scheduler so that killing can actually happen
 		time.Sleep(time.Millisecond)
@@ -146,16 +146,16 @@ func TestRununtilSimulateKillSignal_MultipleTimes(t *testing.T) {
 	}
 }
 
-func TestRununtilSimulateKillSignal_Threadsafe(t *testing.T) {
+func TestRununtilCancelAll_Threadsafe(t *testing.T) {
 	for idx := 0; idx < 100; idx++ {
-		rununtil.SimulateKillSignal()
+		rununtil.CancelAll()
 	}
 }
 
 // Annoyingly this test has to be run by itself to actually fail...
 //	go test -v -run TestKilled_FailsForNonblockingMain
 // Fixed test by not actually sending a kill signal anymore --
-// it now calls rununtil.SimulateKillSignal().
+// it now calls rununtil.CancelAll().
 func TestKilled_FailsForNonblockingMain(t *testing.T) {
 	cancel := rununtil.Killed(func() {})
 	cancel()


### PR DESCRIPTION
I noticed a problem when trying to test a main function using this library, when main errors out before getting to the blocking `rununtil.KillSignal` function. 

The resulting fix ended up in a bit of a rewrite. There is essentially a new interface with all new names. The old functions are still there for backwards compatibility.